### PR TITLE
Wrong and Missing Test cases for 1166

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report--english-.md
+++ b/.github/ISSUE_TEMPLATE/bug-report--english-.md
@@ -1,8 +1,8 @@
 ---
 name: Bug report (English)
 about: Create a bug report to help us improve our content.
-title: ''
-labels: ''
+title: 'test case missing for 1166'
+labels: 'missing test case / wrong test case'
 assignees: ''
 
 ---
@@ -15,17 +15,27 @@ you click on submit.
 
 #### Your LeetCode username
 <!-- Your LeetCode username -->
+xwshiba
 
 
 #### Category of the bug
 - [ ] Question
 - [ ] Solution
 - [ ] Language
-- [ ] Missing Test Cases 
+- [x] Missing Test Cases 
 
 
 #### Description of the bug
 <!-- A clear and concise description of what the bug is. -->
+Question [1166. Design File System](https://leetcode.com/problems/design-file-system/)
+The description suggests that "For example, "/leetcode" and "/leetcode/problems" are valid paths while an empty string "" and "/" are not."
+This means when we input "/" the result should return false instead of true. Currently it's returning true.
+
+```
+["FileSystem","createPath"]
+
+[[],["/",1]]
+```
 
 
 #### Code you used for Submit/Run operation
@@ -34,14 +44,10 @@ Please make sure you wrap your code with ``` tags.
 Otherwise we may reject your request. 
 -->
 
-```
-// Two Sum
-class Solution {
-public:
-    vector<int> twoSum(vector<int> &a, int s) {
 
-    }
-};
+```
+["FileSystem","createPath"]
+[[],["/",1]]
 ```
 
 #### Language used for code
@@ -51,6 +57,7 @@ public:
 #### Expected behavior
 <!-- A clear and concise description of what you expected to happen in
 contrast with what actually happened. -->
+I think the test case should return `[null, false]` instead of `[null, true]`?
 
 
 

--- a/.github/ISSUE_TEMPLATE/bug-report--english-.md
+++ b/.github/ISSUE_TEMPLATE/bug-report--english-.md
@@ -30,11 +30,17 @@ xwshiba
 Question [1166. Design File System](https://leetcode.com/problems/design-file-system/)
 The description suggests that "For example, "/leetcode" and "/leetcode/problems" are valid paths while an empty string "" and "/" are not."
 This means when we input "/" the result should return false instead of true. Currently it's returning true.
-
+Case 1:
 ```
 ["FileSystem","createPath"]
 
 [[],["/",1]]
+```
+
+Case 2:
+```
+["FileSystem","createPath","createPath","createPath","get","createPath","get"]
+[[],["/leet",1],["/leet/code",2],["/leet/code",2],["/leet/code"],["/c/d",1],["/c"]]
 ```
 
 
@@ -49,21 +55,29 @@ Otherwise we may reject your request.
 ["FileSystem","createPath"]
 [[],["/",1]]
 ```
+This below should be included.
+```
+["FileSystem","createPath","createPath","createPath","get","createPath","get"]
+[[],["/leet",1],["/leet/code",2],["/leet/code",2],["/leet/code"],["/c/d",1],["/c"]]
+```
 
 #### Language used for code
 <!-- C++ -->
+Python
 
 
 #### Expected behavior
 <!-- A clear and concise description of what you expected to happen in
 contrast with what actually happened. -->
-I think the test case should return `[null, false]` instead of `[null, true]`?
+Case 1: I think the test case should return `[null, false]` instead of `[null, true]`.
+Case 2: This one should be included.
 
 
 
 #### Screenshots
 <!-- If applicable, add screenshots to explain your issue. -->
 
+![image](https://user-images.githubusercontent.com/64823359/165887852-6f153c68-d796-46f2-bfd8-8bde988c6551.png)
 
 
 #### Additional context


### PR DESCRIPTION
Wrong test case result for 1166. Described in the ticket.

#### Your LeetCode username
<!-- Your LeetCode username -->
xwshiba


#### Category of the bug
- [ ] Question
- [ ] Solution
- [ ] Language
- [x] Missing Test Cases 


#### Description of the bug
Question [1166. Design File System](https://leetcode.com/problems/design-file-system/)
The description suggests that "For example, "/leetcode" and "/leetcode/problems" are valid paths while an empty string "" and "/" are not."
This means when we input "/" the result should return false instead of true. Currently it's returning true.

```
["FileSystem","createPath"]
[[],["/",1]]
```

Second: missing test cases - 
```
["FileSystem","createPath","createPath","createPath","get","createPath","get"]
[[],["/leet",1],["/leet/code",2],["/leet/code",2],["/leet/code"],["/c/d",1],["/c"]]
```
This test case should be added. My solution shows wrong result for this one but successfully passed.


#### Code you used for Submit/Run operation


```
["FileSystem","createPath"]
[[],["/",1]]
```
```
["FileSystem","createPath","createPath","createPath","get","createPath","get"]
[[],["/leet",1],["/leet/code",2],["/leet/code",2],["/leet/code"],["/c/d",1],["/c"]]
```


#### Language used for code
Python
#### Expected behavior
I think for the first one, the test case should return `[null, false]` instead of `[null, true]`.
For the second test case, it should be included.